### PR TITLE
This seems to no longer be up-to-date

### DIFF
--- a/docs/Zoo/04 Developers/13 Accessing Element Data.html
+++ b/docs/Zoo/04 Developers/13 Accessing Element Data.html
@@ -30,6 +30,7 @@ public function set($name, $value);
 
 <p>If it is a repeatable element, iterate over the element itself:</p>
 
+<!-- please check this as it doesn't seem to work anymore -->
 <pre><code>foreach ($element as $self) {
 	$data = $self-&gt;get('value');
 }


### PR DESCRIPTION
foreach ($element as $self) {
	$data = $self-&gt;get('value');
}

doesn't seem to work anymore. The server just crashes at that point where it used to work in earlier versions of ZOO.